### PR TITLE
LOGGING-3249 Support LOGTYPE env var

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -58,7 +58,7 @@ def _get_log_type(log_type=None):
     """
     if log_type:
         return log_type
-    return os.getenv("LOG_TYPE", "")
+    return os.getenv("LOG_TYPE") or os.getenv("LOGTYPE", "")
 
 def _debug_logging_enabled():
     """

--- a/src/test_handler.py
+++ b/src/test_handler.py
@@ -1,0 +1,13 @@
+import unittest
+from src.handler import _get_log_type
+
+def test_get_log_type_with_parameter():
+    assert _get_log_type("PARAMETER") == "PARAMETER"
+
+def test_get_log_type_env_var(monkeypatch):
+    monkeypatch.setenv("LOG_TYPE", "ENV_VAR")
+    assert _get_log_type() == "ENV_VAR"
+
+def test_get_log_type_alt_env_var(monkeypatch):
+    monkeypatch.setenv("LOGTYPE", "ALT_ENV_VAR")
+    assert _get_log_type() == "ALT_ENV_VAR"


### PR DESCRIPTION
Simple fix with unit test, to support both `LOGTYPE` and `LOG_TYPE` env variables.