### PR TITLE
Added logic to preprocess CloudTrail logs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ docutils==0.15.2
 idna==2.10
 jmespath==0.10.0
 multidict==4.7.6
+Pympler==0.9
 python-dateutil==2.8.1
 requests==2.24.0
 s3transfer==0.3.3

--- a/src/handler.py
+++ b/src/handler.py
@@ -221,7 +221,6 @@ async def _fetch_data_from_s3(bucket, key, context):
                     cloudtrail_events=json.loads(log)["Records"]
                     for this_event in cloudtrail_events:
                         # Convert the eventTime to Posix time and pass it to New Relic as a timestamp attribute
-                        logger.info(this_event)
                         this_event['timestamp']=time.mktime((parser.parse(this_event['eventTime'])).timetuple())
                     log_batches.extend(cloudtrail_events)
                 else:


### PR DESCRIPTION
Addresses #28 by performing pre-processing of CloudTrail logs before sending to New Relic, so the JSON array can be split into separate logs and the resulting JSON payloads parsed properly upon ingest into New Relic. This logic is executed automatically based on a regex match of the known CloudTrail log filename structure. (This approach was chosen for simplicity and to avoid the need for special configuration for CloudTrail.) Special logic was also added to use the `eventTime` from the CloudTrail logs to set the `timestamp` attribute. The calculation of the batch size has also been enhanced to avoid the need for manual counters.