### PR TITLE
Allow additional attributes to be sent to New Relic

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -43,6 +43,7 @@ functions:
       LICENSE_KEY: ${env:LICENSE_KEY}
       LOG_TYPE: ${env:LOG_TYPE}
       DEBUG_ENABLED: ${env:DEBUG_ENABLED}
+      ADDITIONAL_ATTRIBUTES: ${env:ADDITIONAL_ATTRIBUTES}
     events:
       - s3:
           bucket: ${env:S3_BUCKET_NAME}

--- a/template.yml
+++ b/template.yml
@@ -14,6 +14,10 @@ Parameters:
     Type: String
     Description: A boolean to determine if you want to output debug messages in the CloudWatch console
     Default: "false"
+  AdditionalTags:
+    Type: String
+    Description: A string containing json object(string,string). These attributes will be added to New Relic payload.
+    Default: "{}"
 
 Metadata:
   AWS::ServerlessRepo::Application:
@@ -43,6 +47,7 @@ Resources:
           LICENSE_KEY: !Ref NRLicenseKey
           LOG_TYPE: !Ref NRLogType
           DEBUG_ENABLED: !Ref DebugEnabled
+          ADDITIONAL_ATTRIBUTES: !Ref AdditionalTags
       Policies:
         - Version: '2012-10-17'
           Statement:


### PR DESCRIPTION
* Add S3 Key to be sent to New relic; If a single s3 bucket is being used for ALB Logs  across SDLC environments, the key metadata can be helpful in differentiating the sources; For e.g <SDCL_ENV>/AWSLogs/<ELBLoadBalancing>
* Add additional attributes to be appended to the payload; This can be used for filtering in New Relic; Teams use Standard tags to differentiate applications etc; Having only S3 Bucket is a deviation from how users query other log data. With this OS Environment variable, the standard tags could be added.