### PR TITLE
improvement: Refactor CloudTrail log processing, support batching(com…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ docutils==0.15.2
 idna==2.10
 jmespath==0.10.0
 multidict==4.7.6
-Pympler==0.9
 python-dateutil==2.8.1
 requests==2.24.0
 s3transfer==0.3.3

--- a/serverless.yml
+++ b/serverless.yml
@@ -26,12 +26,12 @@ provider:
   iamRoleStatements:
     - Effect: "Allow"
       Action:
-       - "s3:GetObject"
+        - "s3:GetObject"
       Resource: "arn:aws:s3:::${env:S3_BUCKET_NAME}/*"
 
 plugins:
   - serverless-python-requirements
-  
+
 custom:
   pythonRequirements:
     dockerizePip: non-linux
@@ -39,10 +39,14 @@ custom:
 functions:
   NewRelic-s3-log-ingestion:
     handler: src/handler.lambda_handler
-    environment: 
+    environment:
       LICENSE_KEY: ${env:LICENSE_KEY}
       LOG_TYPE: ${env:LOG_TYPE}
       DEBUG_ENABLED: ${env:DEBUG_ENABLED}
+      S3_CLOUDTRAIL_LOG_PATTERN: ${env:S3_CLOUDTRAIL_LOG_PATTERN}
+      S3_IGNORE_PATTERN: ${env:S3_IGNORE_PATTERN}
+      BATCH_SIZE_FACTOR: ${env:BATCH_SIZE_FACTOR}
+
     events:
       - s3:
           bucket: ${env:S3_BUCKET_NAME}

--- a/src/handler.py
+++ b/src/handler.py
@@ -36,7 +36,7 @@ MAX_INDIVIDUAL_LOG_SIZE = 250 * 1024
 MAX_FILE_SIZE = 400 * 1000 * 1024
 # Max batch size for sending requests (1MB)
 MAX_BATCH_SIZE = 1000 * 1024
-BATCH_SIZE_FACTOR = 1.5
+
 REQUEST_BATCH_SIZE = 25
 
 completed_requests = 0
@@ -49,6 +49,41 @@ class MaxRetriesException(Exception):
 class BadRequestException(Exception):
     pass
 
+
+def _is_ignore_log_file(key=None, regex_pattern=None):
+    """
+    This functions checks whether this log file should be ignored based on regex pattern.
+    """
+    if not regex_pattern:
+        regex_pattern = os.getenv("S3_IGNORE_PATTERN", "$^")
+
+    return bool(re.search(regex_pattern, key))
+
+
+def _isCloudTrail(key=None, regex_pattern=None):
+    """
+    This functions checks whether this log file is a CloudTrail log based on regex pattern.
+    """
+    if not regex_pattern:
+        regex_pattern = os.getenv(
+            "S3_CLOUDTRAIL_LOG_PATTERN", ".*CloudTrail.*\.json.gz$")
+
+    return bool(re.search(regex_pattern, key))
+
+def _convert_float(s):
+    try:
+        f = float(s)
+    except ValueError:
+        f = 1.5
+    return f
+
+def _get_batch_size_factor(batch_size_factor=None):
+    """
+    This functions gets BATCH_SIZE_FACTOR from env vars.
+    """
+    if batch_size_factor:
+        return batch_size_factor
+    return _convert_float(os.getenv("BATCH_SIZE_FACTOR", "1.5"))
 
 def _get_license_key(license_key=None):
     """
@@ -100,7 +135,9 @@ def _compress_payload(data):
     This method usually returns a list of one element, but can be bigger if the
     payload size is too big
     """
+    logger.debug(f"uncompressed size: {sys.getsizeof(json.dumps(data).encode())}")
     payload = gzip.compress(json.dumps(data).encode())
+    logger.debug(f"compressed size: {sys.getsizeof(payload)}")
     return payload
 
 
@@ -201,7 +238,7 @@ async def _fetch_data_from_s3(bucket, key, context):
         logger.error(
             "The log file uploaded to S3 is larger than the supported max size of 400MB")
         return
-
+    BATCH_SIZE_FACTOR = _get_batch_size_factor()
     s3MetaData = {
         "invoked_function_arn": context.invoked_function_arn,
         "s3_bucket_name": bucket
@@ -213,24 +250,23 @@ async def _fetch_data_from_s3(bucket, key, context):
         batch_counter = 1
         log_batch_size = 0
         start = time.time()
-        isCloudTrail = bool(re.search(".*CloudTrail.*\.json.gz$", key))        
         with open(log_file_url, encoding='utf-8') as log_lines:
-            if isCloudTrail:
+            if _isCloudTrail(key):
                 # This is a CloudTrail log - we need to apply special preprocessing
                 cloudtrail_events=json.loads(log_lines.read())["Records"]
                 for this_event in cloudtrail_events:
                     # Convert the eventTime to Posix time and pass it to New Relic as a timestamp attribute
-                    this_event['timestamp']=time.mktime((parser.parse(this_event['eventTime'])).timetuple())                    
+                    this_event['timestamp']=time.mktime((parser.parse(this_event['eventTime'])).timetuple())
                 log_lines = cloudtrail_events
 
             for index, log in enumerate(log_lines):
-                log_batch_size += sys.getsizeof(log)
+                log_batch_size += sys.getsizeof(str(log))
                 if index % 500 == 0:
                     logger.debug(f"index: {index}")
-                    logger.debug(f"log_batch_size: {log_batch_size}")                    
+                    logger.debug(f"log_batch_size: {log_batch_size}")
                 log_batches.append(log)
                 if log_batch_size > (MAX_BATCH_SIZE * BATCH_SIZE_FACTOR):
-                    logger.debug(f"sending batch: {batch_counter}")
+                    logger.debug(f"sending batch: {batch_counter} log_batch_size: {log_batch_size}")
                     data = {"context": s3MetaData, "entry": log_batches}
                     batch_request.append(create_log_payload_request(data, session))
                     if len(batch_request) >= REQUEST_BATCH_SIZE:
@@ -257,6 +293,12 @@ def lambda_handler(event, context):
     bucket = event['Records'][0]['s3']['bucket']['name']
     key = urllib.parse.unquote_plus(
         event['Records'][0]['s3']['object']['key'], encoding='utf-8')
+
+    # Allow user to skip log file using regex pattern set in env variable: S3_IGNORE_PATTERN 
+    if _is_ignore_log_file(key):
+        logger.debug(f"Ignore log file based on S3_IGNORE_PATTERN: {key}")
+        return {'statusCode': 200, 'message': 'ignored this log'}
+
     try:
         asyncio.run(_fetch_data_from_s3(bucket, key, context))
     except KeyError as e:


### PR DESCRIPTION
Fix #32  
Fix #35

## Support batch send for CloudTrail log 
- Refactored CloudTrail log processing logic to take advantage of existing batch send function 
- Externalized BATCH_SIZE_FACTOR, added S3_CLOUDTRAIL_LOG_PATTERN, S3_IGNORE_PATTERN env variables

> BATCH_SIZE_FACTOR:          affects uncompressed batch size, default: 1.5
> S3_CLOUDTRAIL_LOG_PATTERN:  regex pattern to match CloudTrail log file, default: .*CloudTrail.*\.json.gz$
> S3_IGNORE_PATTERN:          regex pattern to match log file to be ignored/skipped, default: $^