### PR TITLE
Adding support for messages delivered via SNS fanout 

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -323,6 +323,23 @@ async def _fetch_data_from_s3(bucket, key, context):
         logger.debug(f"time elapsed to send to NR Logs: {end - start}")
 
 
+
+def get_s3_event(event):
+    if "s3" in event["Records"][0]:
+        return event
+    elif "Sns" in event["Records"][0]:
+        sns_msg = event["Records"][0]["Sns"]["Message"]
+        try:
+            sns_msg_dict = json.loads(sns_msg)
+            if "Records" in sns_msg_dict and "s3" in sns_msg_dict["Records"][0]:
+                return sns_msg_dict
+        except Exception:
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f"No s3 event detected from SNS message: {sns_msg}")
+    raise Exception("Event type not supported")
+
+
+
 ####################
 #  Lambda handler  #
 ####################
@@ -330,9 +347,11 @@ async def _fetch_data_from_s3(bucket, key, context):
 def lambda_handler(event, context):
     # Get bucket from s3 upload event
     _setting_console_logging_level()
-    bucket = event['Records'][0]['s3']['bucket']['name']
+    s3_event = get_s3_event(event)
+
+    bucket = s3_event['Records'][0]['s3']['bucket']['name']
     key = urllib.parse.unquote_plus(
-        event['Records'][0]['s3']['object']['key'], encoding='utf-8')
+        s3_event['Records'][0]['s3']['object']['key'], encoding='utf-8')
 
     # Allow user to skip log file using regex pattern set in env variable: S3_IGNORE_PATTERN 
     if _is_ignore_log_file(key):

--- a/test/sns-mock.json
+++ b/test/sns-mock.json
@@ -1,0 +1,17 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:us-east-1:1234567890:logging-test:aaaaaaa",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "1",
+                "TopicArn": "arn:aws:sns:us-east-1:1234567890:logging-test",
+                "Subject": "Amazon S3 Notification",
+                "Message": "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"us-east-1\",\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"s3SchemaVersion\":\"1.0\",\"bucket\":{\"name\":\"s3-nr-log-test-bucket\",\"arn\":\"arn:aws:s3:::s3-nr-log-test-bucket\"},\"object\":{\"key\":\"cloudflare-test-data.json.gz\"}}}]}",
+                "Timestamp": "2023-09-01T19:56:13.299Z"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
S3 triggers Have a limitation that can only send one trigger per location, so SNS fanout is required if multiple services need to look at logfiles.   While evaluating multiple logfile systems such as NewRelic, DataDog, Splunk, etc, it's really necessary to be able to keep multiple routes open at the same time.   

This support is inspired a little bit from DataDog's code, also under the Apache License, but modified to fit the features currently in this code base. 