### PR TITLE
Fix python requirements file path in serverless configuration

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -34,6 +34,7 @@ plugins:
 
 custom:
   pythonRequirements:
+    fileName: ./src/requirements.txt
     dockerizePip: non-linux
 
 functions:


### PR DESCRIPTION
### DESCRIPTION
When attempting to deploy the Lambda function using Serverless, the necessary packages are not being deployed. This issue arises because Serverless is unable to locate the requirements.txt file containing the required packages for installation.
### Fix
Added the requirements.txt file path in the serverless.yml configuration. This ensures that Serverless includes the necessary packages during deployment.
### TESTING
[Test Doc](https://docs.google.com/document/d/1qRxbTdl-kUuagS4vEsjmFYSQyMDcqWVHncGqKzToFPc/edit?usp=sharing)