### PR TITLE
NR-560729 Add Japan region support for log ingestion endpoint

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -18,6 +18,7 @@ logger = logging.getLogger()
 
 US_LOGGING_INGEST_HOST = "https://log-api.newrelic.com/log/v1"
 EU_LOGGING_INGEST_HOST = 'https://log-api.eu.newrelic.com/log/v1'
+JP_LOGGING_INGEST_HOST = 'https://log-api.jp.newrelic.com/log/v1'
 LOGGING_LAMBDA_VERSION = '1.3.0'
 LOGGING_PLUGIN_METADATA = {
     'type': "s3-lambda",
@@ -166,11 +167,12 @@ def _get_logging_endpoint(ingest_url=None):
         return ingest_url
     if "NR_LOGGING_ENDPOINT" in os.environ:
         return os.environ["NR_LOGGING_ENDPOINT"]
-    return (
-        EU_LOGGING_INGEST_HOST
-        if _get_license_key().startswith("eu")
-        else US_LOGGING_INGEST_HOST
-    )
+    license_key = _get_license_key()
+    if license_key.startswith("eu"):
+        return EU_LOGGING_INGEST_HOST
+    elif license_key.startswith("jp"):
+        return JP_LOGGING_INGEST_HOST
+    return US_LOGGING_INGEST_HOST
 
 
 def _compress_payload(data):


### PR DESCRIPTION
- Added Japan (JP) region support for New Relic log ingestion                                                                                                                                       
  - License keys prefixed with `jp` now route to `https://log-api.jp.newrelic.com/log/v1`                                                                                                             
  - Updated `_get_logging_endpoint()` to detect JP license keys alongside existing EU/US logic
<img width="1299" height="247" alt="image" src="https://github.com/user-attachments/assets/f69bc522-79e0-4d3b-a396-aa0b489b655f" />
<img width="1713" height="519" alt="Screenshot 2026-05-07 at 11 06 20 AM" src="https://github.com/user-attachments/assets/7405097c-6e5b-46fc-9d42-e7b3ba033fa8" />
Deployed to ap-northeast-1 with a JP-prefixed license key. Lambda invoked successfully (StatusCode 200). The 403 error is expected —   the mock event references an S3 object the Lambda doesn't have access to. This confirms the function deploys and executes correctly; the Japan endpoint  routing is triggered by the "jp" license key prefix, resolving to https://log-api.jp.newrelic.com/log/v1.
