### PR TITLE
Fix JP logging endpoint URL to use nr-data.net

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -18,8 +18,8 @@ logger = logging.getLogger()
 
 US_LOGGING_INGEST_HOST = "https://log-api.newrelic.com/log/v1"
 EU_LOGGING_INGEST_HOST = 'https://log-api.eu.newrelic.com/log/v1'
-JP_LOGGING_INGEST_HOST = 'https://log-api.jp.newrelic.com/log/v1'
-LOGGING_LAMBDA_VERSION = '1.4.0'
+JP_LOGGING_INGEST_HOST = 'https://log-api.jp.nr-data.net/log/v1'
+LOGGING_LAMBDA_VERSION = '1.4.1'
 LOGGING_PLUGIN_METADATA = {
     'type': "s3-lambda",
     'version': LOGGING_LAMBDA_VERSION

--- a/template.yml
+++ b/template.yml
@@ -11,7 +11,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['newrelic', 'logs', 'logging', 'ingestion', 'lambda', 's3']
     HomePageUrl: https://github.com/newrelic/aws_s3_log_ingestion_lambda
-    SemanticVersion: 1.4.0
+    SemanticVersion: 1.4.1
     SourceCodeUrl: https://github.com/newrelic/aws_s3_log_ingestion_lambda
 
   AWS::CloudFormation::Interface: 


### PR DESCRIPTION
 Summary
  
  - Fix JP logging endpoint URL from log-api.jp.newrelic.com to log-api.jp.nr-data.net (DNS not resolving for the former)
  - Bump version to 1.4.1
  
  Context

  The log-api.jp.newrelic.com hostname has no DNS record and is not resolvable from AWS. log-api.jp.nr-data.net resolves correctly and returns 202.
  
  Confirmed log-api.jp.nr-data.net is the correct endpoint for the JP region